### PR TITLE
🔀 :: (#21) implement design system chip component

### DIFF
--- a/core/designsystem/src/main/java/com/example/designsystem/component/chip/ChipType.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/chip/ChipType.kt
@@ -1,0 +1,24 @@
+package com.example.designsystem.component.chip
+
+enum class CardColor {
+    Red, Yellow, Green
+}
+
+enum class CardType {
+    Cookie, Trap, Item, Stage
+}
+
+val CardColor.text: String
+    get() = when (this) {
+        CardColor.Red -> "레드"
+        CardColor.Yellow -> "옐로우"
+        CardColor.Green -> "그린"
+    }
+
+val CardType.text: String
+    get() = when (this) {
+        CardType.Cookie -> "쿠키 카드"
+        CardType.Trap -> "트랩 카드"
+        CardType.Item -> "아이템 카드"
+        CardType.Stage -> "스테이지 카드"
+    }

--- a/core/designsystem/src/main/java/com/example/designsystem/component/chip/CookieboxChip.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/chip/CookieboxChip.kt
@@ -1,0 +1,86 @@
+package com.example.designsystem.component.chip
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.designsystem.theme.CookieboxTheme
+
+@Composable
+fun CookieboxChip(
+    cardColor: CardColor,
+) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = chipBackgroundColor(cardColor = cardColor),
+                shape = RoundedCornerShape(13.dp)
+            )
+            .padding(horizontal = 13.5.dp, vertical = 3.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = cardColor.text,
+            style = CookieboxTheme.typography.captionR,
+            color = Color.Black,
+        )
+    }
+}
+
+@Composable
+fun CookieboxChip(
+    cardType: CardType,
+) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = CookieboxTheme.color.cardTypeChip,
+                shape = RoundedCornerShape(13.dp)
+            )
+            .padding(horizontal = 15.5.dp, vertical = 3.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = cardType.text,
+            style = CookieboxTheme.typography.captionR,
+            color = Color.White,
+        )
+    }
+}
+
+@Composable
+fun chipBackgroundColor(cardColor: CardColor): Color {
+    return when (cardColor) {
+        CardColor.Red -> CookieboxTheme.color.red50
+        CardColor.Yellow -> CookieboxTheme.color.yellow50
+        CardColor.Green -> CookieboxTheme.color.green60
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+fun PreviewCookieboxChip() {
+    Row {
+        Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+            CookieboxChip(cardColor = CardColor.Red)
+            CookieboxChip(cardColor = CardColor.Yellow)
+            CookieboxChip(cardColor = CardColor.Green)
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+            CookieboxChip(cardType = CardType.Cookie)
+            CookieboxChip(cardType = CardType.Trap)
+            CookieboxChip(cardType = CardType.Item)
+            CookieboxChip(cardType = CardType.Stage)
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/example/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/theme/Color.kt
@@ -72,3 +72,6 @@ val Orange60 = Color(0xFFAA6F08)
 val Orange70 = Color(0xFF7A4F06)
 val Orange80 = Color(0xFF493003)
 val Orange90 = Color(0xFF181001)
+
+// TODO: 네이밍 변경하기
+val CardTypeChip = Color(0xFF955A40)

--- a/core/designsystem/src/main/java/com/example/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/theme/Theme.kt
@@ -22,6 +22,7 @@ internal val Colors = CookieboxColor(
     brown80 = Brown80,
     brown90 = Brown90,
     orange40 = Orange40,
+    cardTypeChip = CardTypeChip,
 )
 
 @Immutable
@@ -41,6 +42,7 @@ data class CookieboxColor(
     val brown80: Color,
     val brown90: Color,
     val orange40: Color,
+    val cardTypeChip: Color,
 )
 
 val LocalColor = staticCompositionLocalOf { Colors }


### PR DESCRIPTION
### 개요
- 디자인 시스템 Chip 컴포넌트 구현

### 작업내용
- Color 시스템에 chip 컴포넌트에서 사용될 색상 추가
- CookieboxChip 컴포넌트 개발

### 구현화면 (선택)
<img width="317" alt="스크린샷 2023-11-15 오전 10 02 03" src="https://github.com/cookierun-tcg-service-developer/CookieBox-Android/assets/85855341/362017b2-9392-4acf-bbbd-c0fb4f037592">

### 기타사항 (선택)
- enum 타입 두 개를 사용해야 하므로 하나의 컴포저블 내에서 처리하기 애매하고, 별도로 네이밍된 컴포넌트로 분리하기에는 기능상 유사한 부분이 많아 같은 이름으로 네이밍하고 파라미터로 구분되도록 했습니다.