### PR TITLE
🔀 :: (#31) implement design system deck item component

### DIFF
--- a/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/CookieboxDeckItem.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/CookieboxDeckItem.kt
@@ -32,15 +32,14 @@ fun CookieboxDeckItem(
     deckItemType: DeckItemType,
     imageUrl: String,
     count: Int,
-    imageWidth: Dp,
-    imageHeight: Dp,
     onMinusClick: () -> Unit,
 ) {
    Box(
        modifier = modifier
            .size(
-               width = imageWidth,
-               height = imageHeight,
+               width = deckItemSize(deckItemType),
+               height = if (deckItemType == DeckItemType.BottomSheet) deckItemSize(deckItemType) + 12.dp
+               else deckItemSize(deckItemType) + 40.dp,
            ),
    ) {
        AsyncImage(
@@ -95,6 +94,14 @@ fun CookieboxDeckItem(
        }
    }
 }
+
+fun deckItemSize(deckItemType: DeckItemType): Dp {
+    return when(deckItemType) {
+        DeckItemType.BottomSheet -> 44.dp
+        DeckItemType.Detail -> 104.dp
+    }
+}
+
 @Preview(showBackground = true, backgroundColor = 0xFFFFFF)
 @Composable
 fun CookieboxDeckItemPreview() {
@@ -103,8 +110,6 @@ fun CookieboxDeckItemPreview() {
             deckItemType = DeckItemType.BottomSheet,
             imageUrl = "",
             count = 1,
-            imageWidth = 48.dp,
-            imageHeight = 66.dp,
         ) {}
 
         Spacer(modifier = Modifier.width(10.dp))
@@ -113,8 +118,6 @@ fun CookieboxDeckItemPreview() {
             deckItemType = DeckItemType.Detail,
             imageUrl = "",
             count = 2,
-            imageWidth = 104.dp,
-            imageHeight = 144.dp,
         ) {}
     }
 }

--- a/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/CookieboxDeckItem.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/CookieboxDeckItem.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.designsystem.icon.IcMinus
@@ -36,11 +36,7 @@ fun CookieboxDeckItem(
 ) {
    Box(
        modifier = modifier
-           .size(
-               width = deckItemSize(deckItemType),
-               height = if (deckItemType == DeckItemType.BottomSheet) deckItemSize(deckItemType) + 12.dp
-               else deckItemSize(deckItemType) + 40.dp,
-           ),
+           .size(deckItemSize(deckItemType)),
    ) {
        AsyncImage(
            model = imageUrl,
@@ -95,10 +91,10 @@ fun CookieboxDeckItem(
    }
 }
 
-fun deckItemSize(deckItemType: DeckItemType): Dp {
+fun deckItemSize(deckItemType: DeckItemType): DpSize {
     return when(deckItemType) {
-        DeckItemType.BottomSheet -> 44.dp
-        DeckItemType.Detail -> 104.dp
+        DeckItemType.BottomSheet -> DpSize(48.dp, 66.dp)
+        DeckItemType.Detail -> DpSize(104.dp, 144.dp)
     }
 }
 

--- a/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/CookieboxDeckItem.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/CookieboxDeckItem.kt
@@ -1,0 +1,120 @@
+package com.example.designsystem.component.deck_item
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.designsystem.icon.IcMinus
+import com.example.designsystem.theme.CookieboxTheme
+
+@Composable
+fun CookieboxDeckItem(
+    modifier: Modifier = Modifier,
+    deckItemType: DeckItemType,
+    imageUrl: String,
+    count: Int,
+    imageWidth: Dp,
+    imageHeight: Dp,
+    onMinusClick: () -> Unit,
+) {
+   Box(
+       modifier = modifier
+           .size(
+               width = imageWidth,
+               height = imageHeight,
+           ),
+   ) {
+       AsyncImage(
+           model = imageUrl,
+           contentDescription = "cookieImage",
+       )
+
+       if (deckItemType == DeckItemType.BottomSheet) {
+           IcMinus(
+               modifier = Modifier
+                   .size(16.dp)
+                   .background(
+                       color = CookieboxTheme.color.cardMinus,
+                       shape = RoundedCornerShape(
+                           topEnd = 2.dp,
+                           bottomStart = 6.dp,
+                       )
+                   )
+                   .align(Alignment.TopEnd)
+                   .clickable(
+                       interactionSource = remember { MutableInteractionSource() },
+                       indication = null,
+                       onClick = onMinusClick,
+                   ),
+               tint = Color.White,
+           )
+       }
+
+       Row(
+           modifier = Modifier
+               .fillMaxWidth()
+               .background(
+                   Brush.verticalGradient(
+                       listOf(
+                           Color.Transparent,
+                           Color.Black,
+                       )
+                   )
+               )
+               .padding(
+                   vertical = if (deckItemType == DeckItemType.Detail) 10.dp
+                   else 0.dp,
+               )
+               .align(Alignment.BottomCenter),
+           horizontalArrangement = Arrangement.Center
+       ) {
+           Text(
+               text = "x$count",
+               style = CookieboxTheme.typography.textMediumR,
+               color = Color.White,
+           )
+       }
+   }
+}
+@Preview(showBackground = true, backgroundColor = 0xFFFFFF)
+@Composable
+fun CookieboxDeckItemPreview() {
+    Row {
+        CookieboxDeckItem(
+            deckItemType = DeckItemType.BottomSheet,
+            imageUrl = "",
+            count = 1,
+            imageWidth = 48.dp,
+            imageHeight = 66.dp,
+        ) {}
+
+        Spacer(modifier = Modifier.width(10.dp))
+
+        CookieboxDeckItem(
+            deckItemType = DeckItemType.Detail,
+            imageUrl = "",
+            count = 2,
+            imageWidth = 104.dp,
+            imageHeight = 144.dp,
+        ) {}
+    }
+}

--- a/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/DeckItemType.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/DeckItemType.kt
@@ -1,0 +1,5 @@
+package com.example.designsystem.component.deck_item
+
+enum class DeckItemType {
+    BottomSheet, Detail
+}

--- a/core/designsystem/src/main/java/com/example/designsystem/component/dialog/CookieboxDialog.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/dialog/CookieboxDialog.kt
@@ -90,7 +90,7 @@ fun CookieBoxDialog(
                         contentDescription = "cookieImage",
                         contentScale = ContentScale.Fit
                     )
-                    Text(
+                    Box(
                         modifier = Modifier
                             .fillMaxWidth()
                             .background(
@@ -103,7 +103,6 @@ fun CookieBoxDialog(
                             )
                             .height(40.dp)
                             .align(Alignment.BottomCenter),
-                        text = "",
                     )
                 }
 

--- a/core/designsystem/src/main/java/com/example/designsystem/component/dialog/CookieboxDialog.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/dialog/CookieboxDialog.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.SpanStyle
@@ -79,15 +81,31 @@ fun CookieBoxDialog(
                     .padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-
-                AsyncImage(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(250.dp),
-                    model = imageUrl,
-                    contentDescription = "cookieImage",
-                    contentScale = ContentScale.Fit
-                )
+                Box {
+                    AsyncImage(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(250.dp),
+                        model = imageUrl,
+                        contentDescription = "cookieImage",
+                        contentScale = ContentScale.Fit
+                    )
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                Brush.verticalGradient(
+                                    listOf(
+                                        Color.Transparent,
+                                        Color.White,
+                                    )
+                                )
+                            )
+                            .height(40.dp)
+                            .align(Alignment.BottomCenter),
+                        text = "",
+                    )
+                }
 
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -257,26 +275,26 @@ fun CookieBoxDialogPreview() {
             onDismissRequest = {},
         )
 
-        CookieBoxDeleteDialog(
-            onDismissRequest = { /*TODO*/ },
-            onCardDelete = {},
-        ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "아클레어 컨트롤",
-                    style = CookieboxTheme.typography.textSmallR,
-                    color = CookieboxTheme.color.red50,
-                )
-                Text(
-                    text = "을 삭제하면 되돌릴 수 없어요",
-                    style = CookieboxTheme.typography.textSmallR,
-                    color = CookieboxTheme.color.grayscale40,
-                )
-            }
-        }
+//        CookieBoxDeleteDialog(
+//            onDismissRequest = { /*TODO*/ },
+//            onCardDelete = {},
+//        ) {
+//            Column(
+//                modifier = Modifier.fillMaxWidth(),
+//                horizontalAlignment = Alignment.CenterHorizontally,
+//            ) {
+//                Spacer(modifier = Modifier.height(8.dp))
+//                Text(
+//                    text = "아클레어 컨트롤",
+//                    style = CookieboxTheme.typography.textSmallR,
+//                    color = CookieboxTheme.color.red50,
+//                )
+//                Text(
+//                    text = "을 삭제하면 되돌릴 수 없어요",
+//                    style = CookieboxTheme.typography.textSmallR,
+//                    color = CookieboxTheme.color.grayscale40,
+//                )
+//            }
+//        }
     }
 }

--- a/core/designsystem/src/main/java/com/example/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/theme/Color.kt
@@ -75,3 +75,4 @@ val Orange90 = Color(0xFF181001)
 
 // TODO: 네이밍 변경하기
 val CardTypeChip = Color(0xFF955A40)
+val CardMinus = Color(0xFFF20D0D)

--- a/core/designsystem/src/main/java/com/example/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/theme/Theme.kt
@@ -24,6 +24,7 @@ internal val Colors = CookieboxColor(
     brown90 = Brown90,
     orange40 = Orange40,
     cardTypeChip = CardTypeChip,
+    cardMinus = CardMinus,
 )
 
 @Immutable
@@ -45,6 +46,7 @@ data class CookieboxColor(
     val brown90: Color,
     val orange40: Color,
     val cardTypeChip: Color,
+    val cardMinus: Color,
 )
 
 val LocalColor = staticCompositionLocalOf { Colors }


### PR DESCRIPTION
### 개요
- DeckItem 컴포넌트 퍼블리싱

### 작업내용
- 필요한 color 추가
- DeckItemType 생성
- DeckItem 컴포넌트 퍼블리싱

### 구현화면 (선택)
<img width="421" alt="image" src="https://github.com/cookierun-tcg-service-developer/CookieBox-Android/assets/84944098/d1d7d6ad-ea89-41e3-9586-2e0636849380">
<img width="375" alt="image" src="https://github.com/cookierun-tcg-service-developer/CookieBox-Android/assets/84944098/f038b047-83e1-4ccf-98e9-b9e5eaf0efb0">

### 기타사항 (선택)
- image는 자리만 차지하고 있습니다.
- 저번에 빼먹었던 Dialog에도 그라데이션을 추가했습니다. (이미지에서 White가 잘 안보여 보여주기 위해서 Black으로 스크린샷)
- 일단 Text로 text = ""으로 처리하고 그라데이션을 추가했는데 더 좋은 방법이 있을까요?
