### PR TITLE
🔀 :: (#27) implement design system menu component

### DIFF
--- a/core/designsystem/src/main/java/com/example/designsystem/component/menu/CookieboxMenu.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/menu/CookieboxMenu.kt
@@ -1,0 +1,58 @@
+package com.example.designsystem.component.menu
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ExposedDropdownMenuBoxScope
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.designsystem.theme.CookieboxTheme
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun ExposedDropdownMenuBoxScope.CookieboxMenu(
+    items: List<String>,
+    menuMaxHeight: Dp,
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    onItemClicked: (String) -> Unit,
+) {
+    MaterialTheme(
+        shapes = MaterialTheme.shapes.copy(medium = RoundedCornerShape(bottomStart = 8.dp, bottomEnd = 8.dp)),
+    ) {
+        ExposedDropdownMenu(
+            modifier = Modifier
+                .background(
+                    color = CookieboxTheme.color.grayscale80,
+                    shape = RoundedCornerShape(bottomStart = 8.dp, bottomEnd = 8.dp),
+                )
+                .heightIn(max = menuMaxHeight),
+            expanded = expanded,
+            onDismissRequest = onDismissRequest,
+        ) {
+            items.forEach { item ->
+                DropdownMenuItem(
+                    onClick = {
+                        onDismissRequest()
+                        onItemClicked(item)
+                    },
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 11.dp),
+                ) {
+                    Text(
+                        text = item,
+                        style = CookieboxTheme.typography.textMediumR,
+                        color = Color.White,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/example/designsystem/component/menu/CookieboxMenuBox.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/menu/CookieboxMenuBox.kt
@@ -1,0 +1,108 @@
+package com.example.designsystem.component.menu
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ExposedDropdownMenuBox
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.designsystem.icon.IcChevronDown
+import com.example.designsystem.icon.IcChevronUp
+import com.example.designsystem.theme.CookieboxTheme
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun CookieboxMenuBox(
+    modifier: Modifier = Modifier,
+    value: String,
+    isInitialValue: Boolean = true,
+    items: List<String>,
+    menuMaxHeight: Dp = 264.dp,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    onDismissRequest: () -> Unit,
+    onItemClicked: (String) -> Unit,
+) {
+    ExposedDropdownMenuBox(
+        modifier = modifier,
+        expanded = expanded,
+        onExpandedChange = onExpandedChange,
+    ) {
+        TextField(
+            value = value,
+            onValueChange = {},
+            readOnly = true,
+            colors = TextFieldDefaults.textFieldColors(
+                backgroundColor = if (expanded || !isInitialValue) CookieboxTheme.color.grayscale80 else CookieboxTheme.color.grayscale5,
+                textColor = if (expanded || !isInitialValue) Color.White else CookieboxTheme.color.grayscale40,
+                unfocusedIndicatorColor = Color.Transparent,
+                focusedIndicatorColor = CookieboxTheme.color.grayscale40
+            ),
+            shape = if (expanded) RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp) else RoundedCornerShape(8.dp),
+            textStyle = CookieboxTheme.typography.textMediumR,
+            trailingIcon = {
+                val dynamicTint = if (expanded || !isInitialValue) Color.White else CookieboxTheme.color.grayscale40
+
+                if (expanded) IcChevronDown(tint = Color.White) else IcChevronUp(tint = dynamicTint)
+            }
+        )
+        CookieboxMenu(
+            items = items,
+            expanded = expanded,
+            menuMaxHeight = menuMaxHeight,
+            onDismissRequest = onDismissRequest,
+            onItemClicked = onItemClicked,
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+fun PreviewCookieboxMenu() {
+    var startLevelExpanded by remember { mutableStateOf(false) }
+    var endLevelExpanded by remember { mutableStateOf(false) }
+
+    var startLevel by remember { mutableStateOf("시작 LV") }
+    var endLevel by remember { mutableStateOf("끝 LV") }
+
+    val startLevelOptions = listOf("시작 LV", "LV.1", "LV.2", "LV.3", "LV.4", "LV.5")
+    val endLevelOptions = listOf("끝 LV", "LV.1", "LV.2", "LV.3", "LV.4", "LV.5")
+
+    Row(
+        modifier = Modifier.height(300.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        CookieboxMenuBox(
+            modifier = Modifier.weight(1f),
+            value = startLevel,
+            isInitialValue = startLevel == startLevelOptions.first(),
+            items = startLevelOptions,
+            expanded = startLevelExpanded,
+            onExpandedChange = { startLevelExpanded = it },
+            onDismissRequest = { startLevelExpanded = false },
+            onItemClicked = { startLevel = it },
+        )
+        CookieboxMenuBox(
+            modifier = Modifier.weight(1f),
+            value = endLevel,
+            isInitialValue = endLevel == endLevelOptions.first(),
+            items = endLevelOptions,
+            expanded = endLevelExpanded,
+            onExpandedChange = { endLevelExpanded = it },
+            onDismissRequest = { endLevelExpanded = false },
+            onItemClicked = { endLevel = it },
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/example/designsystem/component/menu/CookieboxMenuBox.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/menu/CookieboxMenuBox.kt
@@ -45,7 +45,11 @@ fun CookieboxMenuBox(
             onValueChange = {},
             readOnly = true,
             colors = TextFieldDefaults.textFieldColors(
-                backgroundColor = if (expanded || !isInitialValue) CookieboxTheme.color.grayscale80 else CookieboxTheme.color.grayscale5,
+                backgroundColor = if (expanded || !isInitialValue) {
+                    CookieboxTheme.color.grayscale80
+                } else {
+                    CookieboxTheme.color.grayscale5
+                },
                 textColor = if (expanded || !isInitialValue) Color.White else CookieboxTheme.color.grayscale40,
                 unfocusedIndicatorColor = Color.Transparent,
                 focusedIndicatorColor = CookieboxTheme.color.grayscale40

--- a/core/designsystem/src/main/java/com/example/designsystem/component/menu/CookieboxMenuBox.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/menu/CookieboxMenuBox.kt
@@ -27,10 +27,10 @@ import com.example.designsystem.theme.CookieboxTheme
 fun CookieboxMenuBox(
     modifier: Modifier = Modifier,
     value: String,
-    isInitialValue: Boolean = true,
+    expanded: Boolean,
     items: List<String>,
     menuMaxHeight: Dp = 264.dp,
-    expanded: Boolean,
+    isInitialValue: Boolean = true,
     onExpandedChange: (Boolean) -> Unit,
     onDismissRequest: () -> Unit,
     onItemClicked: (String) -> Unit,

--- a/core/designsystem/src/main/java/com/example/designsystem/component/menu/CookieboxMenuBox.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/menu/CookieboxMenuBox.kt
@@ -31,8 +31,8 @@ fun CookieboxMenuBox(
     items: List<String>,
     menuMaxHeight: Dp = 264.dp,
     isInitialValue: Boolean = true,
-    onExpandedChange: (Boolean) -> Unit,
     onDismissRequest: () -> Unit,
+    onExpandedChange: (Boolean) -> Unit,
     onItemClicked: (String) -> Unit,
 ) {
     ExposedDropdownMenuBox(
@@ -94,8 +94,8 @@ fun PreviewCookieboxMenu() {
             isInitialValue = startLevel == startLevelOptions.first(),
             items = startLevelOptions,
             expanded = startLevelExpanded,
-            onExpandedChange = { startLevelExpanded = it },
             onDismissRequest = { startLevelExpanded = false },
+            onExpandedChange = { startLevelExpanded = it },
             onItemClicked = { startLevel = it },
         )
         CookieboxMenuBox(
@@ -104,8 +104,8 @@ fun PreviewCookieboxMenu() {
             isInitialValue = endLevel == endLevelOptions.first(),
             items = endLevelOptions,
             expanded = endLevelExpanded,
-            onExpandedChange = { endLevelExpanded = it },
             onDismissRequest = { endLevelExpanded = false },
+            onExpandedChange = { endLevelExpanded = it },
             onItemClicked = { endLevel = it },
         )
     }


### PR DESCRIPTION
### 개요
- 디자인 시스템 Menu 컴포넌트 개발

### 작업내용
- CookieboxMenu 및 CookieboxMenuBox 컴포넌트 구현

### 구현영상 (선택)

https://github.com/cookierun-tcg-service-developer/CookieBox-Android/assets/85855341/e5c00e80-f7b7-466c-bd32-e0ba4d5b70ed

### 기타사항 (선택)
- Material2 ExposedDropdownMenu의 경우 내부적으로 상위 컴포넌트 하단에 위치하도록 설정되어 있고 변경이 불가능한듯 하여, 아래쪽에서 펼쳐지도록 했습니다.
- CookieboxMenu 컴포넌트의 경우 ExposedDropdownMenuBoxScope 내에서 동작하므로 CookieboxMenuBox 에서 공통적으로 Preview를 구현했습니다.
