### PR TITLE
🔀 :: (#42) implement no ripple clickable extension

### DIFF
--- a/core/designsystem/src/main/java/com/example/designsystem/component/card_item/CookieboxCardItem.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/card_item/CookieboxCardItem.kt
@@ -1,10 +1,6 @@
 package com.example.designsystem.component.card_item
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,11 +27,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.designsystem.R
+import com.example.designsystem.component.modifier.cookieboxClickable
+import com.example.designsystem.component.modifier.cookieboxCombinedClickable
 import com.example.designsystem.icon.IcMinus
 import com.example.designsystem.icon.IcPlus
 import com.example.designsystem.theme.CookieboxTheme
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun CookieboxCardItem(
     imageUrl: String,
@@ -47,9 +44,7 @@ fun CookieboxCardItem(
     Card(
         modifier = Modifier
             .size(width = 104.dp, height = 144.dp)
-            .combinedClickable(
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() },
+            .cookieboxCombinedClickable(
                 onClick = {
                     if (count == 0) onPlusClick()
                 },
@@ -82,11 +77,7 @@ fun CookieboxCardItem(
                     IcPlus(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable(
-                                indication = null,
-                                interactionSource = remember { MutableInteractionSource() },
-                                onClick = onPlusClick
-                            ),
+                            .cookieboxClickable(onClick = onPlusClick),
                         tint = Color.White
                     )
                     CookieboxCountBadge(
@@ -96,11 +87,7 @@ fun CookieboxCardItem(
                     IcMinus(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable(
-                                indication = null,
-                                interactionSource = remember { MutableInteractionSource() },
-                                onClick = onMinusClick
-                            ),
+                            .cookieboxClickable(onClick = onMinusClick),
                         tint = Color.White
                     )
                 }

--- a/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/CookieboxDeckItem.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/CookieboxDeckItem.kt
@@ -1,8 +1,6 @@
 package com.example.designsystem.component.deck_item
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -14,7 +12,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -23,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.example.designsystem.component.modifier.cookieboxClickable
 import com.example.designsystem.icon.IcMinus
 import com.example.designsystem.theme.CookieboxTheme
 
@@ -34,65 +32,63 @@ fun CookieboxDeckItem(
     count: Int,
     onMinusClick: () -> Unit,
 ) {
-   Box(
-       modifier = modifier
-           .size(deckItemSize(deckItemType)),
-   ) {
-       AsyncImage(
-           model = imageUrl,
-           contentDescription = "cookieImage",
-       )
+    Box(
+        modifier = modifier
+            .size(deckItemSize(deckItemType)),
+    ) {
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = "cookieImage",
+        )
 
-       if (deckItemType == DeckItemType.BottomSheet) {
-           IcMinus(
-               modifier = Modifier
-                   .size(16.dp)
-                   .background(
-                       color = CookieboxTheme.color.cardMinus,
-                       shape = RoundedCornerShape(
-                           topEnd = 2.dp,
-                           bottomStart = 6.dp,
-                       )
-                   )
-                   .align(Alignment.TopEnd)
-                   .clickable(
-                       interactionSource = remember { MutableInteractionSource() },
-                       indication = null,
-                       onClick = onMinusClick,
-                   ),
-               tint = Color.White,
-           )
-       }
+        if (deckItemType == DeckItemType.BottomSheet) {
+            IcMinus(
+                modifier = Modifier
+                    .size(16.dp)
+                    .background(
+                        color = CookieboxTheme.color.cardMinus,
+                        shape = RoundedCornerShape(
+                            topEnd = 2.dp,
+                            bottomStart = 6.dp,
+                        )
+                    )
+                    .align(Alignment.TopEnd)
+                    .cookieboxClickable(
+                        onClick = onMinusClick,
+                    ),
+                tint = Color.White,
+            )
+        }
 
-       Row(
-           modifier = Modifier
-               .fillMaxWidth()
-               .background(
-                   Brush.verticalGradient(
-                       listOf(
-                           Color.Transparent,
-                           Color.Black,
-                       )
-                   )
-               )
-               .padding(
-                   vertical = if (deckItemType == DeckItemType.Detail) 10.dp
-                   else 0.dp,
-               )
-               .align(Alignment.BottomCenter),
-           horizontalArrangement = Arrangement.Center
-       ) {
-           Text(
-               text = "x$count",
-               style = CookieboxTheme.typography.textMediumR,
-               color = Color.White,
-           )
-       }
-   }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.verticalGradient(
+                        listOf(
+                            Color.Transparent,
+                            Color.Black,
+                        )
+                    )
+                )
+                .padding(
+                    vertical = if (deckItemType == DeckItemType.Detail) 10.dp
+                    else 0.dp,
+                )
+                .align(Alignment.BottomCenter),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "x$count",
+                style = CookieboxTheme.typography.textMediumR,
+                color = Color.White,
+            )
+        }
+    }
 }
 
 private fun deckItemSize(deckItemType: DeckItemType): DpSize {
-    return when(deckItemType) {
+    return when (deckItemType) {
         DeckItemType.BottomSheet -> DpSize(48.dp, 66.dp)
         DeckItemType.Detail -> DpSize(104.dp, 144.dp)
     }

--- a/core/designsystem/src/main/java/com/example/designsystem/component/dialog/CookieboxDialog.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/dialog/CookieboxDialog.kt
@@ -1,8 +1,6 @@
 package com.example.designsystem.component.dialog
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,7 +14,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -34,6 +31,7 @@ import com.example.designsystem.component.button.CookieboxButton
 import com.example.designsystem.component.chip.CardColor
 import com.example.designsystem.component.chip.CardType
 import com.example.designsystem.component.chip.CookieboxChip
+import com.example.designsystem.component.modifier.cookieboxClickable
 import com.example.designsystem.icon.IcCross
 import com.example.designsystem.theme.CookieboxTheme
 
@@ -220,10 +218,8 @@ fun CookieBoxDeleteDialog(
                 Text(
                     modifier = Modifier
                         .padding(horizontal = 20.dp, vertical = 10.dp)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                            onClick = onDismissRequest
+                        .cookieboxClickable(
+                            onClick = onDismissRequest,
                         ),
                     text = "취소",
                     style = CookieboxTheme.typography.textMediumR,
@@ -232,10 +228,8 @@ fun CookieBoxDeleteDialog(
                 Text(
                     modifier = Modifier
                         .padding(horizontal = 20.dp, vertical = 10.dp)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                            onClick = onCardDelete
+                        .cookieboxClickable(
+                            onClick = onCardDelete,
                         ),
                     text = "삭제",
                     style = CookieboxTheme.typography.textMediumR,

--- a/core/designsystem/src/main/java/com/example/designsystem/component/dialog/CookieboxFilterDialog.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/dialog/CookieboxFilterDialog.kt
@@ -1,8 +1,6 @@
 package com.example.designsystem.component.dialog
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -29,6 +27,7 @@ import com.example.designsystem.component.button.ButtonType
 import com.example.designsystem.component.button.CookieboxButton
 import com.example.designsystem.component.button.CookieboxSegmentedButton
 import com.example.designsystem.component.menu.CookieboxMenuBox
+import com.example.designsystem.component.modifier.cookieboxClickable
 import com.example.designsystem.icon.IcCross
 import com.example.designsystem.theme.CookieboxTheme
 
@@ -65,11 +64,7 @@ fun CookieboxFilterDialog(
                 color = Color.Black
             )
             IcCross(
-                modifier = Modifier.clickable(
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() },
-                    onClick = onDismissRequest
-                )
+                modifier = Modifier.cookieboxClickable(onClick = onDismissRequest),
             )
         }
 

--- a/core/designsystem/src/main/java/com/example/designsystem/component/modifier/CookieboxClickable.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/modifier/CookieboxClickable.kt
@@ -1,0 +1,37 @@
+package com.example.designsystem.component.modifier
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+
+fun Modifier.cookieboxClickable(
+    indication: Indication? = null,
+    onClick: () -> Unit,
+) = composed {
+    clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = indication,
+        onClick = onClick
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+fun Modifier.cookieboxCombinedClickable(
+    indication: Indication? = null,
+    onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null,
+    onDoubleClick: (() -> Unit)? = null,
+) = composed {
+    combinedClickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = indication,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick
+    )
+}


### PR DESCRIPTION
### 개요
- 리플 효과 없는 clickable을 Modifier의 확장 함수로 구현

### 작업내용
- cookieboxClickable 구현 및 적용
- cookieboxCombinedClickable 구현 및 적용

### 기타사항 (선택)
- feature 모듈에서 clickable을 사용할 때도 해당 함수를 사용하면 될 듯 합니다
