### PR TITLE
🔀 :: (#50) fix deck list screen

### DIFF
--- a/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/CookieboxDeckListItem.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/deck_item/CookieboxDeckListItem.kt
@@ -40,6 +40,13 @@ fun CookieboxDeckListItem(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Box(modifier = Modifier.size(160.dp, 220.dp)) {
+            if (isChecked) {
+                IcCheckMark(
+                    modifier = Modifier.align(Alignment.Center),
+                    tint = Color.Black
+                )
+            }
+
             AsyncImage(
                 modifier = Modifier
                     .fillMaxSize()
@@ -57,12 +64,6 @@ fun CookieboxDeckListItem(
                     )
                 } else null
             )
-            if (isChecked) {
-                IcCheckMark(
-                    modifier = Modifier.align(Alignment.Center),
-                    tint = Color.Black
-                )
-            }
         }
         Text(
             text = deckName,

--- a/core/designsystem/src/main/java/com/example/designsystem/component/dialog/CookieboxDialog.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/dialog/CookieboxDialog.kt
@@ -246,27 +246,27 @@ private fun CookieBoxDialogPreview() {
     Column(
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        CookieBoxDialog(
-            cookieName = "명량한 쿠키",
-            cookieLevel = 2,
-            cookieHp = 4,
-            imageUrl = "",
-            cardType = CardType.Cookie,
-            cardColor = CardColor.Yellow,
-            skills = listOf(
-                "1데미지를 준다",
-                "3데미지를 준다",
-                "3데미지를 준다. 그리고 자신의 브레이크 에리어에 있는 LV.1의 카드를 한 장까지 선택한다. 그 카드를 트래시에 놓는다.",
-            ),
-            skillCost = listOf(
-                "<믹스2>",
-                "<옐로3><믹스1>",
-                "<옐로2><믹스2>",
-            ),
-            onTextCopy = {},
-            onCardSave = {},
-            onDismissRequest = {},
-        )
+//        CookieBoxDialog(
+//            cookieName = "명량한 쿠키",
+//            cookieLevel = 2,
+//            cookieHp = 4,
+//            imageUrl = "",
+//            cardType = CardType.Cookie,
+//            cardColor = CardColor.Yellow,
+//            skills = listOf(
+//                "1데미지를 준다",
+//                "3데미지를 준다",
+//                "3데미지를 준다. 그리고 자신의 브레이크 에리어에 있는 LV.1의 카드를 한 장까지 선택한다. 그 카드를 트래시에 놓는다.",
+//            ),
+//            skillCost = listOf(
+//                "<믹스2>",
+//                "<옐로3><믹스1>",
+//                "<옐로2><믹스2>",
+//            ),
+//            onTextCopy = {},
+//            onCardSave = {},
+//            onDismissRequest = {},
+//        )
 
 //        CookieBoxDeleteDialog(
 //            onDismissRequest = { /*TODO*/ },
@@ -289,5 +289,43 @@ private fun CookieBoxDialogPreview() {
 //                )
 //            }
 //        }
+
+        CookieBoxDeleteDialog(
+            onDismissRequest = { /*TODO*/ },
+            onCardDelete = {},
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = "삭제하시려는 덱은",
+                    style = CookieboxTheme.typography.textSmallR,
+                    color = CookieboxTheme.color.grayscale40,
+                )
+                Text(
+                    text = "아클레어 컨트롤",
+                    style = CookieboxTheme.typography.captionR,
+                    color = CookieboxTheme.color.orange40,
+                )
+                Text(
+                    text = "딸기크레페 부스팅 2",
+                    style = CookieboxTheme.typography.captionR,
+                    color = CookieboxTheme.color.orange40,
+                )
+                Text(
+                    text = "커피트럭",
+                    style = CookieboxTheme.typography.captionR,
+                    color = CookieboxTheme.color.orange40,
+                )
+                Text(
+                    text = "씬키스드 개조",
+                    style = CookieboxTheme.typography.captionR,
+                    color = CookieboxTheme.color.orange40,
+                )
+            }
+        }
     }
 }

--- a/feature/deck/src/main/java/com/example/deck/DeckListScreen.kt
+++ b/feature/deck/src/main/java/com/example/deck/DeckListScreen.kt
@@ -47,17 +47,33 @@ fun DeckListScreen() {
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(2.dp)
             ) {
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(6.dp))
                 Text(
-                    text = "아클레어 컨트롤",
-                    style = CookieboxTheme.typography.textSmallR,
-                    color = CookieboxTheme.color.red50,
-                )
-                Text(
-                    text = "을 삭제하면 되돌릴 수 없어요",
+                    text = "삭제하시려는 덱은",
                     style = CookieboxTheme.typography.textSmallR,
                     color = CookieboxTheme.color.grayscale40,
+                )
+                Text(
+                    text = "아클레어 컨트롤",
+                    style = CookieboxTheme.typography.captionR,
+                    color = CookieboxTheme.color.orange40,
+                )
+                Text(
+                    text = "딸기크레페 부스팅 2",
+                    style = CookieboxTheme.typography.captionR,
+                    color = CookieboxTheme.color.orange40,
+                )
+                Text(
+                    text = "커피트럭",
+                    style = CookieboxTheme.typography.captionR,
+                    color = CookieboxTheme.color.orange40,
+                )
+                Text(
+                    text = "씬키스드 개조",
+                    style = CookieboxTheme.typography.captionR,
+                    color = CookieboxTheme.color.orange40,
                 )
             }
         }
@@ -89,7 +105,7 @@ fun DeckListScreen() {
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "덱 리스트",
+                text = if (!isChecked) "덱 리스트" else "덱 삭제하기",
                 style = CookieboxTheme.typography.titleMediumB,
                 color = Color.Black,
             )
@@ -122,22 +138,17 @@ fun DeckListScreen() {
             IcFilter(tint = CookieboxTheme.color.grayscale40)
         }
 
-        val testList = mutableListOf(false, false, false, false, false, false, false)
-
         LazyVerticalGrid(
             modifier = Modifier.padding(bottom = 16.dp),
             columns = GridCells.Fixed(2),
         ) {
-            items(testList.size) {
+            items(7) {
                 CookieboxDeckListItem(
                     imageUrl = "",
                     deckName = "에클레어 컨트롤",
-                    isChecked = testList[it],
+                    isChecked = isChecked,
                     onCardClick = {},
-                    onCardLongClick = {
-                        testList[it] = !testList[it]
-                        isChecked = true
-                    }
+                    onCardLongClick = { isChecked = !isChecked }
                 )
             }
         }


### PR DESCRIPTION
### 개요
- DeckListScreen 오류 수정

### 작업내용
- DeckItem을 길게 클릭 시 체크 아이콘이 안뜨던 오류 수정
- 선택 삭제 버튼을 클릭 시 뜨던 다이얼로그가 디자인과 달라서 수정
- DeckItem이 체크 되어있을 때 title 수정

### 구현화면 (선택)
![image](https://github.com/cookierun-tcg-service-developer/CookieBox-Android/assets/84944098/147a8348-9ee5-491a-a160-37db21f5c673)
![image](https://github.com/cookierun-tcg-service-developer/CookieBox-Android/assets/84944098/0c5da87c-99ef-4a37-83b2-549eab9d1454)

### 참고사항 (선택)
- 체크 했을 때 현재 item마다 state를 부여하지 않아서 한번에 체크됩니다.

