### PR TITLE
🔀 :: (#62) fix delete selection button

### DIFF
--- a/feature/deck/src/main/java/com/example/deck/DeckListScreen.kt
+++ b/feature/deck/src/main/java/com/example/deck/DeckListScreen.kt
@@ -122,7 +122,7 @@ fun DeckListScreen(
                 modifier = Modifier.alpha(if (isChecked) 1f else 0f),
                 text = "선택 삭제",
                 buttonType = ButtonType.Primary
-            ) { isShowDialog = true }
+            ) { if (isChecked) isShowDialog = true }
         }
 
         CookieboxTextField(

--- a/feature/deck/src/main/java/com/example/deck/DeckListScreen.kt
+++ b/feature/deck/src/main/java/com/example/deck/DeckListScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -116,7 +117,12 @@ fun DeckListScreen(
                 style = CookieboxTheme.typography.titleMediumB,
                 color = Color.Black,
             )
-            if (isChecked) CookieboxButton(text = "선택 삭제", buttonType = ButtonType.Primary) { isShowDialog = true }
+
+            CookieboxButton(
+                modifier = Modifier.alpha(if (isChecked) 1f else 0f),
+                text = "선택 삭제",
+                buttonType = ButtonType.Primary
+            ) { isShowDialog = true }
         }
 
         CookieboxTextField(


### PR DESCRIPTION
### 개요
- 선택 삭제 버튼 버그 수정

### 작업내용
- alpha를 이용해서 선택 삭제 버튼의 자리를 미리 잡아놓기

### 구현영상 (선택)
https://github.com/cookierun-tcg-service-developer/CookieBox-Android/assets/84944098/053a20cd-d74a-4bf9-b754-d33e72b54d1b

### 기타사항 (선택)
- 원래는 조건에 따라 컴포넌트가 생성이 되어서 row에 verticalAlignment Center 속성으로 인해 Row에 있는 위치가 변경되었어서 이를 수정했습니다.
